### PR TITLE
feature# Enable metrics recording to prometheus.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help:
 	@echo '    make test            Run unit tests with coverage report.'
 	@echo '    make devenv          Prepare devenv for test or build.'
 	@echo '    make fetch-deps      Run govendor fetch for deps.'
-	@echo '    make get-tools         Prepare go tools depended.'
+	@echo '    make get-tools       Prepare go tools depended.'
 	@echo '    make clean           Clean the directory tree.'
 	@echo
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	blockchainc "github.com/DSiSc/blockchain/config"
 	"github.com/DSiSc/craft/log"
+	"github.com/DSiSc/craft/monitor"
 	consensusc "github.com/DSiSc/galaxy/consensus/config"
 	participatesc "github.com/DSiSc/galaxy/participates/config"
 	rolec "github.com/DSiSc/galaxy/role/config"
@@ -42,6 +43,11 @@ const (
 	API_GATEWAY_TCP_ADDR = "apigateway.tcpAddr"
 	// Default parameter for solo block producer
 	SOLO_TEST_BLOCK_PRODUCER_INTERVAL = "soloTestBlockInterval.time"
+
+	// prometheus
+	PROMETHEUS_ENABLED  = "prometheus.enabled"
+	PROMETHEUS_PORT     = "prometheus.port"
+	PROMETHEUS_MAX_CONN = "prometheus.maxOpenConnections"
 )
 
 type AlgorithmConfig struct {
@@ -70,6 +76,9 @@ type NodeConfig struct {
 	BlockInterval uint8
 	//algorithm config
 	AlgorithmConf AlgorithmConfig
+
+	// prometheus
+	PrometheusConf monitor.PrometheusConfig
 }
 
 type Config struct {
@@ -166,6 +175,7 @@ func NewNodeConfig() NodeConfig {
 	consensusConf := conf.NewConsensusConf()
 	blockChainConf := conf.NewBlockChainConf()
 	blockIntervalTime := conf.GetBlockProducerInterval()
+	prometheusConf := conf.GetPrometheusConf()
 
 	return NodeConfig{
 		Account:          nodeAccount,
@@ -177,6 +187,7 @@ func NewNodeConfig() NodeConfig {
 		BlockChainConf:   blockChainConf,
 		BlockInterval:    blockIntervalTime,
 		AlgorithmConf:    algorithmConf,
+		PrometheusConf:   prometheusConf,
 	}
 }
 
@@ -259,4 +270,19 @@ func (self *Config) GetNodeAccount() *account.Account {
 func (self *Config) GetBlockProducerInterval() uint8 {
 	blockInterval, _ := strconv.Atoi(self.GetConfigItem(SOLO_TEST_BLOCK_PRODUCER_INTERVAL).(string))
 	return uint8(blockInterval)
+}
+
+func (self *Config) GetPrometheusConf() monitor.PrometheusConfig {
+	prometheusEnabled := false
+	enabled := self.GetConfigItem(PROMETHEUS_ENABLED).(string)
+	if "true" == enabled {
+		prometheusEnabled = true
+	}
+	prometheusPort := self.GetConfigItem(PROMETHEUS_PORT).(string)
+	prometheusMaxConn, _ := strconv.Atoi(self.GetConfigItem(PROMETHEUS_MAX_CONN).(string))
+	return monitor.PrometheusConfig{
+		PrometheusEnabled: prometheusEnabled,
+		PrometheusPort:    prometheusPort,
+		PrometheusMaxConn: prometheusMaxConn,
+	}
 }

--- a/config/config.json
+++ b/config/config.json
@@ -28,5 +28,10 @@
   },
   "soloTestBlockInterval": {
     "time": "2"
+  },
+  "prometheus": {
+    "enabled": "true",
+    "port": "47780",
+    "maxOpenConnections": "3"
   }
 }

--- a/node/node.go
+++ b/node/node.go
@@ -2,11 +2,16 @@ package node
 
 import (
 	"fmt"
+	"net"
+	"sync"
+	"time"
+
 	"github.com/DSiSc/apigateway"
 	rpc "github.com/DSiSc/apigateway/rpc/core"
 	"github.com/DSiSc/blockchain"
 	gconf "github.com/DSiSc/craft/config"
 	"github.com/DSiSc/craft/log"
+	"github.com/DSiSc/craft/monitor"
 	"github.com/DSiSc/craft/types"
 	"github.com/DSiSc/galaxy/consensus"
 	consensusc "github.com/DSiSc/galaxy/consensus/common"
@@ -20,9 +25,6 @@ import (
 	"github.com/DSiSc/producer"
 	"github.com/DSiSc/txpool"
 	"github.com/DSiSc/validator"
-	"net"
-	"sync"
-	"time"
 )
 
 var (
@@ -218,6 +220,9 @@ func (self *Node) startSwitch() {
 func (self *Node) Start() {
 	self.stratRpc()
 	self.startSwitch()
+
+	monitor.StartPrometheusServer(self.config.PrometheusConf)
+
 	go self.mainLoop()
 }
 
@@ -232,6 +237,9 @@ func (self *Node) Stop() error {
 			return fmt.Errorf("closing listener error")
 		}
 	}
+
+	monitor.StopPrometheusServer()
+
 	self.blockSwitch.Stop()
 	self.txSwitch.Stop()
 	EventUnregister()


### PR DESCRIPTION
- add three config options under "prometheus"
- start a http server with the startup of the node, and shutdown when stop the node
- record block height, tx number in current block and total tx number as a starter