### PR TITLE
optimize#optimze code to limist the num of goroutine

### DIFF
--- a/config/genesis.go
+++ b/config/genesis.go
@@ -241,4 +241,3 @@ func GetChainIdFromConfig() (uint64, error) {
 
 	return chainId, nil
 }
-

--- a/propagator/tx_propagator.go
+++ b/propagator/tx_propagator.go
@@ -7,7 +7,6 @@ import (
 	"github.com/DSiSc/justitia/common"
 	"github.com/DSiSc/p2p"
 	"github.com/DSiSc/p2p/message"
-	"github.com/DSiSc/txpool"
 	"sync"
 )
 
@@ -37,9 +36,8 @@ func NewTxPropagator(p2p p2p.P2PAPI, txOut chan<- interface{}, eventCenter types
 // BlockEventFunc get a EventFunc that can be bound to event center
 func (tp *TxPropagator) TxEventFunc(event interface{}) {
 	switch event.(type) {
-	case types.Hash:
-		tx := txpool.GetTxByHash(event.(types.Hash))
-		tp.broadCastTx(tx)
+	case *types.Transaction:
+		tp.broadCastTx(event.(*types.Transaction))
 	default:
 		log.Warn("received a unknown transaction event")
 	}

--- a/propagator/tx_propagator_test.go
+++ b/propagator/tx_propagator_test.go
@@ -102,10 +102,10 @@ func TestTxPropagator_TxEventFunc(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(int32(1), tp.isRuning)
 
-	txHash := types.Hash{}
-	tp.eventCenter.Notify(types.EventAddTxToTxPool, txHash)
+	tx := &types.Transaction{}
+	tp.eventCenter.Notify(types.EventAddTxToTxPool, tx)
 
-	tk := time.NewTicker(100 * time.Second)
+	tk := time.NewTicker(time.Second)
 	select {
 	case <-broadcastChan:
 	case <-tk.C:


### PR DESCRIPTION
1. use grpool to limit the num of go routine
2. use tx as event msg to reduce the use of txpool lock